### PR TITLE
Remove Trailing HTML Tag & basic YAML Syntax "- " for Attributes

### DIFF
--- a/lotus.js
+++ b/lotus.js
@@ -57,6 +57,8 @@ const parseLine = (line, stack) => {
 
   if (tag.startsWith("@")) {
     currentParent.node.addAttribute(tag.substring(1), value);
+  } else if (tag.startsWith("- ")) {
+    currentParent.node.addAttribute(tag.substring(2), value);
   } else {
     const newNode = new Node(tag, {}, value);
     currentParent.node.addChild(newNode);

--- a/lotus.js
+++ b/lotus.js
@@ -73,7 +73,10 @@ const lotus = (lotus) => {
   lines.forEach((line) => parseLine(line, stack));
 
   // Adjusts to remove the <html> tag from the result
-  return root.toHtml().substring(6);
+  let result = root.toHtml().substring(6);
+  result = result.substring(0, result.length - 7);
+
+  return result;
 };
 
 module.exports = lotus;


### PR DESCRIPTION
Not sure which direction you intend to take with the syntax, but I'll attempt to contribute now 😃 

- Removed the trailing html tag e63f208c5a423f62b0afa850844eeaf893d07da1
- Added if else check for `- `, substring also adjusts accordingly 51ccfabe246307d1ff5907afb07497472a770b66
  - Results in basic yaml style syntax support for attributes

```yaml
html:
  head:
    title: A template engine for writing human-friendly HTML
  body:
    div:
      - class: container
        p: Make HTML more enjoyable and reduce stress!
        img:
          - src: /path/to/logo.avif
          - alt: Lotus logo
```